### PR TITLE
feat: add nvidia layout + docs

### DIFF
--- a/via-layouts/amd-pc/README.md
+++ b/via-layouts/amd-pc/README.md
@@ -1,0 +1,41 @@
+# VIA Layout - AMD PC
+
+This document describes the key mappings and layers for the "AMD PC" VIA configuration for the DoysPad.
+
+
+## Layer 0 (Default)
+
+| Keycap # | Key Mapping      |
+|----------|------------------|
+| 1        | KC_MYCM (open my computer)          |
+| 2        | KC_WWW_SEARCH (open search)   |
+| 3        | Screenshot       |
+| 4        | Record instant replay         |
+| 5        | Toggle recording         |
+| 6        | Activate 2x frame gen         |
+| 7       | Toggle overlay         |
+| 8       | KC_MPLY (play/pause)         |
+
+**Encoders:**
+- Encoder 1: KC_VOLU / KC_VOLD (volume up / down)
+  - Encoder (top) press, mute    
+- Encoder 2: RGB_VAD / RGB_VAI (RGB brightness up / down)
+  -  Encoder (bottom) press activate next layer
+ 
+
+## Layer 1 (press knob 2)
+
+| Keycap # | Key Mapping      |
+|----------|------------------|
+| 1        | RGB mode prev   |
+| 2        | RGB mode next   |
+| 3        | Bluetooth connection 1       |
+| 4        | Bluetooth connection 2         |
+| 5        | Toggle RGBs         |
+| 6        |  Disconnect bluetooth        |
+| 7       | Battery level        |
+| 8       | Change color / hue +         |
+
+ 
+
+ 

--- a/via-layouts/nvidia-pc/README.md
+++ b/via-layouts/nvidia-pc/README.md
@@ -1,0 +1,41 @@
+# VIA Layout - Nvidia PC
+
+This document describes the key mappings and layers for the "Nvidia PC" VIA configuration for the DoysPad.
+
+
+## Layer 0 (Default)
+
+| Keycap # | Key Mapping      |
+|----------|------------------|
+| 1        | KC_MYCM (open my computer)          |
+| 2        | KC_WWW_SEARCH (open search)   |
+| 3        | Screenshot       |
+| 4        | Record instant replay         |
+| 5        | Toggle instant replay        |
+| 6        | Open filters (for RTX HDR)         |
+| 7       | Toggle performance stats         |
+| 8       | KC_MPLY (play/pause)         |
+
+**Encoders:**
+- Encoder 1: KC_VOLU / KC_VOLD (volume up / down)
+  - Encoder (top) press, mute    
+- Encoder 2: RGB_VAD / RGB_VAI (RGB brightness up / down)
+  -  Encoder (bottom) press activate next layer
+ 
+
+## Layer 1 (press knob 2)
+
+| Keycap # | Key Mapping      |
+|----------|------------------|
+| 1        | RGB mode prev   |
+| 2        | RGB mode next   |
+| 3        | Bluetooth connection 1       |
+| 4        | Bluetooth connection 2         |
+| 5        | Toggle RGBs         |
+| 6        |  Disconnect bluetooth        |
+| 7       | Battery level        |
+| 8       | Change color / hue +         |
+
+ 
+
+ 

--- a/via-layouts/nvidia-pc/nvidia-pc.layout.json
+++ b/via-layouts/nvidia-pc/nvidia-pc.layout.json
@@ -1,0 +1,94 @@
+{
+  "name": "DoysPad",
+  "vendorProductId": 2862000886,
+  "macros": [
+    "{KC_LCTL,KC_LSFT,KC_I}",
+    "{KC_LCTL,KC_LSFT,KC_E}",
+    "{KC_LCTL,KC_LSFT,KC_S}",
+    "{KC_LALT,KC_LSFT,KC_G}",
+    "{KC_LCTL,KC_LSFT,KC_O}",
+    "{KC_LALT,KC_F3}",
+    "{KC_LALT,KC_F10}",
+    "{KC_LALT,KC_F1}",
+    "{KC_LALT,KC_F3}",
+    "{KC_LALT,KC_LSFT,KC_F10}",
+    "{KC_LALT,KC_R}",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
+  "layers": [
+    [
+      "KC_MYCM",
+      "KC_DEL",
+      "KC_WWW_SEARCH",
+      "KC_MUTE",
+      "MACRO(7)",
+      "MACRO(6)",
+      "MACRO(9)",
+      "MO(1)",
+      "MACRO(8)",
+      "MACRO(10)",
+      "KC_MPLY",
+      "KC_NO"
+    ],
+    [
+      "RGB_RMOD",
+      "KC_TRNS",
+      "RGB_MOD",
+      "CUSTOM(4)",
+      "CUSTOM(7)",
+      "CUSTOM(8)",
+      "CUSTOM(4)",
+      "KC_TRNS",
+      "CUSTOM(9)",
+      "CUSTOM(5)",
+      "RGB_HUI",
+      "KC_NO"
+    ],
+    [
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_NO"
+    ],
+    [
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_TRNS",
+      "KC_NO"
+    ]
+  ],
+  "encoders": [
+    [
+      ["KC_VOLU", "KC_VOLD"],
+      ["RGB_VAD", "RGB_VAI"],
+      ["KC_TRNS", "KC_TRNS"],
+      ["KC_TRNS", "KC_TRNS"]
+    ],
+    [
+      ["RGB_VAI", "RGB_VAD"],
+      ["RGB_MOD", "RGB_RMOD"],
+      ["KC_TRNS", "KC_TRNS"],
+      ["KC_TRNS", "KC_TRNS"]
+    ]
+  ]
+}


### PR DESCRIPTION
 

adding initial nvidia shortcuts for 
- capture screenshot
- capture last N seconds
- toggle instant replay
- open filters (to apply RTX HDR)
- show performance overlay
 